### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A datetime formatting service implemented as an MCP server for the Claude Deskto
 
 > **Note**: This package has been tested only on macOS. Windows compatibility has not been verified.
 
+<a href="https://glama.ai/mcp/servers/y4oh57n2vq"><img width="380" height="200" src="https://glama.ai/mcp/servers/y4oh57n2vq/badge" /></a>
+
 ## Prerequisites
 
 Before using mcp-datetime, ensure you have the following tools installed:


### PR DESCRIPTION
This PR adds a badge for the `mcp-datetime` server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/y4oh57n2vq

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.