### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To install Datetime Formatting Server for Claude Desktop automatically via [Smit
 npx -y @smithery/cli install mcp-datetime --client claude
 ```
 
+### Installing Manually
 If you need to install the package directly (e.g., for development or source code inspection), you can use one of these methods:
 
 - Install from PyPI

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # mcp-datetime
 
+[![smithery badge](https://smithery.ai/badge/mcp-datetime)](https://smithery.ai/server/mcp-datetime)
 [![Python Version](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![MCP Version](https://img.shields.io/badge/mcp-1.1.1-green.svg)](https://github.com/anaisbetts/mcp)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -56,6 +57,14 @@ Config file location (macOS):
 ```
 
 ## About Installation
+
+### Installing via Smithery
+
+To install Datetime Formatting Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-datetime):
+
+```bash
+npx -y @smithery/cli install mcp-datetime --client claude
+```
 
 If you need to install the package directly (e.g., for development or source code inspection), you can use one of these methods:
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Datetime Formatting Server for Claude Desktop using Smithery CLI. This update facilitates an easier installation process for users.
2. Introduces a badge to display the number of installations from Smithery: https://smithery.ai/server/mcp-datetime

Let me know if any adjustments are needed!